### PR TITLE
If a server allows players to have nick names, check the text string against those nicknames as well

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.16.2
 yarn_mappings=1.16.2+build.47
-loader_version=0.9.3+build.207
+loader_version=0.9.1+build.205
 # Mod Properties
-mod_version=0.1.0
+mod_version=0.1.1
 maven_group=dzwdz
 archives_base_name=chat_heads
 # Dependencies

--- a/src/main/java/dzwdz/chat_heads/mixin/ChatListenerHudMixin.java
+++ b/src/main/java/dzwdz/chat_heads/mixin/ChatListenerHudMixin.java
@@ -31,9 +31,7 @@ public class ChatListenerHudMixin {
                 }
             }
         }
-        System.out.println("not found, now looking for "+textString);
         for (PlayerListEntry p: MinecraftClient.getInstance().getNetworkHandler().getPlayerList()) {
-            System.out.println("\tcheck against "+p.getDisplayName().getString());
             if (textString.contains(p.getDisplayName().getString())) {
                 EntryPoint.lastSender = p;
                 return;

--- a/src/main/java/dzwdz/chat_heads/mixin/ChatListenerHudMixin.java
+++ b/src/main/java/dzwdz/chat_heads/mixin/ChatListenerHudMixin.java
@@ -1,6 +1,7 @@
 package dzwdz.chat_heads.mixin;
 
 import dzwdz.chat_heads.EntryPoint;
+import java.util.UUID;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatListenerHud;
 import net.minecraft.client.network.PlayerListEntry;
@@ -11,8 +12,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.UUID;
-
 @Mixin(ChatListenerHud.class)
 public class ChatListenerHudMixin {
     @Inject(
@@ -21,14 +20,23 @@ public class ChatListenerHudMixin {
     )
     public void onChatMessage(MessageType messageType, Text message, UUID senderUuid, CallbackInfo callbackInfo) {
         EntryPoint.lastSender = MinecraftClient.getInstance().getNetworkHandler().getPlayerListEntry(senderUuid);
+        String textString = message.getString();
         if (EntryPoint.lastSender == null) {
-            for (String part : message.getString().split("(§.)|[^\\w]")) {
+            for (String part : textString.split("(§.)|[^\\w]")) {
                 if (part.isEmpty()) continue;
                 PlayerListEntry p = MinecraftClient.getInstance().getNetworkHandler().getPlayerListEntry(part);
                 if (p != null) {
                     EntryPoint.lastSender = p;
                     return;
                 }
+            }
+        }
+        System.out.println("not found, now looking for "+textString);
+        for (PlayerListEntry p: MinecraftClient.getInstance().getNetworkHandler().getPlayerList()) {
+            System.out.println("\tcheck against "+p.getDisplayName().getString());
+            if (textString.contains(p.getDisplayName().getString())) {
+                EntryPoint.lastSender = p;
+                return;
             }
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
     "chat_heads.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.9.3+build.207",
+    "fabricloader": ">=0.9.1+build.205",
     "minecraft": "1.16.2"
   },
   "custom": {


### PR DESCRIPTION
Some servers have a nickname command, that allows users to set their name on the server. This can even include &xxx / §xxx names to allow rainbow colors in nicknames. I added a check so if the original name search fails, nicknames are checked. Doing that with string.contains on the unstyled strings instead of the word split compare, because of the possible style codes in nicknames, and also because servers may add markers to nicknames so they don't "word match" the nickname any more.

(Also, I downgraded the required loader version just a little bit, so people who started using 1.16.2 early aren't forced to upgrade; the mod doesn't really need the newer version).
