### PR TITLE
fix npe when HttpTextures are not registered via SkinManager

### DIFF
--- a/common/src/main/java/dzwdz/chat_heads/mixin/HttpTextureMixin.java
+++ b/common/src/main/java/dzwdz/chat_heads/mixin/HttpTextureMixin.java
@@ -29,6 +29,10 @@ public abstract class HttpTextureMixin implements HttpTextureAccessor {
 
     @Inject(method = "loadCallback", at = @At("HEAD"))
     public void chatheads$registerBlendedHeadTexture(NativeImage image, CallbackInfo ci) {
+        if (chatheads$textureLocation == null) {
+            return;
+        }
+
         Minecraft.getInstance().getTextureManager()
                 .register(getBlendedHeadLocation(chatheads$textureLocation), new DynamicTexture(extractBlendedHead(image)));
 


### PR DESCRIPTION
This fixes player rendering breaking with certain other mods. An example of such a mod is [Essential](https://essential.gg/).