### PR TITLE
Fix for no visible server messages sent through Polymer early play networking api

### DIFF
--- a/common/src/main/java/dzwdz/chat_heads/ChatHeads.java
+++ b/common/src/main/java/dzwdz/chat_heads/ChatHeads.java
@@ -107,6 +107,10 @@ public class ChatHeads {
         ClientPacketListener connection = Minecraft.getInstance().getConnection();
         Map<String, PlayerInfo> nicknameCache = new HashMap<>();
 
+        if (connection == null) {
+            return null;
+        }
+
         // check each word consisting only out of allowed player name characters
         for (String word : message.getString().split("(§.)|[^\\w]")) {
             if (word.isEmpty()) continue;


### PR DESCRIPTION
When some mod tries to send message to client  through [Polymer early play networking api](https://github.com/Patbox/polymer/blob/dev/1.19.3/polymer-networking/src/main/java/eu/pb4/polymer/networking/api/EarlyPlayNetworkHandler.java), message is not shown on client and chat heads just throw null pointer exception [example code snippet of the issue](https://github.com/Skidamek/YetAnotherAuthMod/blob/2545c08221fadf8a4da8be92deb867cf8babfa91/src/main/java/pl/skidam/yetanotherauthmod/LimboHandler.java#L146). There is a fix, thanks for a such a great mod! :)