### PR TITLE
fix newlines being expanded in fabric.mod.json

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -35,7 +35,9 @@ processResources {
     inputs.property "version", project.mod_version
 
     filesMatching("fabric.mod.json") {
-        expand "version": project.mod_version
+        expand ("version": project.mod_version) {
+            escapeBackslash = true
+        }
     }
 }
 


### PR DESCRIPTION
Before this fix the \n in the json string was being expanded to a literal line feed character, causing the json file to be invalid since escape characters are not allowed inside json string and must be escaped.

Here's examples of the JSON that results from this gradle script before and after the fix:

<details>
<summary>Before</summary>

```json
{
  "schemaVersion": 1,
  "id": "chat_heads",
  "version": "0.10.5",
  "name": "Chat Heads",
  "description": "See who are you chatting with!
This mod adds player heads next to their chat messages.",
  "authors": [
    "dzwdz"
  ],
  "contact": {
    "sources": "https://github.com/dzwdz/chat_heads"
  },
  "license": "MPL-2.0",
  "icon": "assets/chat_heads/icon.png",
  "environment": "client",
  "entrypoints": {
    "main": [
      "dzwdz.chat_heads.fabric.ChatHeads"
    ],
    "modmenu": [
      "dzwdz.chat_heads.fabric.config.ModMenuImpl"
    ]
  },
  "mixins": [
    "chat_heads.mixins.json"
  ],
  "depends": {
    "fabricloader": ">=0.14.5",
    "minecraft": "1.19.x"
  },
  "suggests": {
    "cloth-config2": ">=6.0.0"
  },
  "custom": {
    "modupdater": {
      "strategy": "curseforge",
      "projectID": 407206
    }
  }
}
```
</details>


<details>
<summary>After</summary>

```json
{
  "schemaVersion": 1,
  "id": "chat_heads",
  "version": "0.10.5",
  "name": "Chat Heads",
  "description": "See who are you chatting with!\nThis mod adds player heads next to their chat messages.",
  "authors": [
    "dzwdz"
  ],
  "contact": {
    "sources": "https://github.com/dzwdz/chat_heads"
  },
  "license": "MPL-2.0",
  "icon": "assets/chat_heads/icon.png",
  "environment": "client",
  "entrypoints": {
    "main": [
      "dzwdz.chat_heads.fabric.ChatHeads"
    ],
    "modmenu": [
      "dzwdz.chat_heads.fabric.config.ModMenuImpl"
    ]
  },
  "mixins": [
    "chat_heads.mixins.json"
  ],
  "depends": {
    "fabricloader": ">=0.14.5",
    "minecraft": "1.19.x"
  },
  "suggests": {
    "cloth-config2": ">=6.0.0"
  },
  "custom": {
    "modupdater": {
      "strategy": "curseforge",
      "projectID": 407206
    }
  }
}
```
</details>