### PR TITLE
Fix for missing system console messages

### DIFF
--- a/common/src/main/java/dzwdz/chat_heads/ChatHeads.java
+++ b/common/src/main/java/dzwdz/chat_heads/ChatHeads.java
@@ -191,6 +191,8 @@ public class ChatHeads {
 
     @Nullable
     private static PlayerInfo getPlayerInfo(String name, ClientPacketListener connection, Map<String, PlayerInfo> profileNameCache, Map<String, PlayerInfo> nicknameCache) {
+		if (name == null) return null;
+
         // manually translate nickname to profile name (needed for non-displayname nicknames)
         name = CONFIG.getProfileName(name).replaceAll(NON_NAME_REGEX, "");
 


### PR DESCRIPTION
I noticed that system messages sent through the server console (e.g. `say hello`) were not showing up in my client.  The error below appeared anytime one of these messages was sent.  Adding a check for a null `name` fixed the error and allowed the messages to be shown again.

```
[01:37:52] [Render thread/ERROR]: Error executing task on Client
java.lang.NullPointerException: Cannot invoke "String.replaceAll(String, String)" because the return value of "dzwdz.chat_heads.config.ChatHeadsConfig.getProfileName(String)" is null
	at dzwdz.chat_heads.ChatHeads.getPlayerInfo(ChatHeads.java:195) ~[chat_heads-0.10.23-fabric-1.20.2.jar:?]
	at dzwdz.chat_heads.ChatHeads.detectPlayer(ChatHeads.java:146) ~[chat_heads-0.10.23-fabric-1.20.2.jar:?]
	at dzwdz.chat_heads.ChatHeads.handleAddedMessage(ChatHeads.java:113) ~[chat_heads-0.10.23-fabric-1.20.2.jar:?]
	at net.minecraft.client.network.message.MessageHandler.handler$zek000$chat_heads$chatheads$handleAddedDisguisedMessage(MessageHandler.java:1539) ~[client-intermediary.jar:?]
	at net.minecraft.client.network.message.MessageHandler.method_45745(MessageHandler.java) ~[client-intermediary.jar:?]
	at net.minecraft.client.network.message.MessageHandler.process(MessageHandler.java:88) ~[client-intermediary.jar:?]
	at net.minecraft.client.network.message.MessageHandler.onProfilelessMessage(MessageHandler.java:123) ~[client-intermediary.jar:?]
	at net.minecraft.client.network.ClientPlayNetworkHandler.onProfilelessChatMessage(ClientPlayNetworkHandler.java:885) ~[client-intermediary.jar:?]
	at net.minecraft.network.packet.s2c.play.ProfilelessChatMessageS2CPacket.apply(ProfilelessChatMessageS2CPacket.java:21) ~[client-intermediary.jar:?]
	at net.minecraft.network.packet.s2c.play.ProfilelessChatMessageS2CPacket.apply(ProfilelessChatMessageS2CPacket.java:8) ~[client-intermediary.jar:?]
	at net.minecraft.network.NetworkThreadUtils.method_11072(NetworkThreadUtils.java:23) ~[client-intermediary.jar:?]
	at net.minecraft.util.thread.ThreadExecutor.executeTask(ThreadExecutor.java:156) ~[client-intermediary.jar:?]
	at net.minecraft.util.thread.ReentrantThreadExecutor.executeTask(ReentrantThreadExecutor.java:23) ~[client-intermediary.jar:?]
	at net.minecraft.util.thread.ThreadExecutor.runTask(ThreadExecutor.java:130) ~[client-intermediary.jar:?]
	at net.minecraft.util.thread.ThreadExecutor.runTasks(ThreadExecutor.java:115) ~[client-intermediary.jar:?]
	at net.minecraft.client.MinecraftClient.render(MinecraftClient.java:1231) ~[client-intermediary.jar:?]
	at net.minecraft.client.MinecraftClient.run(MinecraftClient.java:856) ~[client-intermediary.jar:?]
	at net.minecraft.client.main.Main.main(Main.java:253) ~[minecraft-1.20.2-client.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:470) ~[fabric-loader-0.14.24.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) ~[fabric-loader-0.14.24.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) ~[fabric-loader-0.14.24.jar:?]
	at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:87) ~[NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:130) ~[NewLaunch.jar:?]
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) ~[NewLaunch.jar:?]

```