### PR TITLE
Allow nicknames with accents to be detected by fallback heuristics

### DIFF
--- a/common/src/main/java/dzwdz/chat_heads/ChatHeads.java
+++ b/common/src/main/java/dzwdz/chat_heads/ChatHeads.java
@@ -59,7 +59,7 @@ import static dzwdz.chat_heads.config.SenderDetection.UUID_ONLY;
 
 public class ChatHeads {
     public static final String MOD_ID = "chat_heads";
-    public static final String NON_NAME_REGEX = "(§.)|[^\\w]";
+    public static final String NON_NAME_REGEX = "(§.)|[^\\p{L}\\p{N}_]";
     public static final Logger LOGGER = LogManager.getLogger(MOD_ID);
     public static final ResourceLocation DISABLE_RESOURCE = new ResourceLocation(MOD_ID, "disable");
 


### PR DESCRIPTION
Hello !

Regarding Issue #88 , I open this PR to change NON_NAME_REGEX so it can properly work with nicknames with accents (or any kind of letter from any language in fact)

Previous regex `(§.)|[^\w]` did catch any Minecraft formatting code (§a, §r, §x,...) and any non alphanumeric char. I did not change the first part since chat formatting code indeeds need to be escaped, but I replaced the second part: `\p{L}` matches any kind of letter from any language (including letters with accents), and `\p{N}` matches any kind of numeric character from any language too. (I also added _ because underscores were already allowed in the first regexp)

Please let me know if I need to adapt anything else !