### PR TITLE
Update fabric_loader_version_range to 0.16.14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ cloth_config_version=26.1.154
 
 # fabric
 fabric_loader_version=0.18.5
-fabric_loader_version_range=>=0.18.5
+fabric_loader_version_range=>=0.16.14
 modmenu_version=18.0.0-alpha.8
 
 # neoforge


### PR DESCRIPTION
The fabric loader version specified in fabric.mod.json needs to be the *minimum* supported version, which for 26.1 is 0.16.14